### PR TITLE
Implement NAVER news comments crawler

### DIFF
--- a/naver_news.py
+++ b/naver_news.py
@@ -37,9 +37,10 @@ def extract(url, debug=False):
         for content in contents:
             print(content.text)
 
+    driver.close()
     return contents
 
 
 if __name__ == "__main__":
-    url = 'https://news.naver.com/main/read.nhn?m_view=1&includeAllCount=true&mode=LSD&mid=shm&sid1=102&oid=022&aid=0003479487'
+    url = 'https://news.naver.com/main/read.nhn?m_view=1&includeAllCount=true&mode=LSD&mid=shm&sid1=100&oid=011&aid=0003760926'
     extract(url, debug=True)

--- a/naver_news.py
+++ b/naver_news.py
@@ -1,0 +1,45 @@
+import time
+from selenium import webdriver
+
+
+def extract(url, debug=False):
+    driver = webdriver.Chrome('/Users/taek/Documents/WebDriver/chromedriver')
+    driver.implicitly_wait(30)
+    driver.get(url)
+
+    # Turn off the 'clean bot' at comments.
+    try:
+        cleanbot = driver.find_element_by_css_selector('a.u_cbox_cleanbot_setbutton')
+        cleanbot.click()
+        time.sleep(0.1)
+
+        cleanbot_check = driver.find_element_by_id('cleanbot_dialog_checkbox_cbox_module')
+        cleanbot_check.click()
+        time.sleep(0.1)
+
+        ok_button = driver.find_element_by_css_selector('button.u_cbox_layer_cleanbot2_extrabtn')
+        ok_button.click()
+        time.sleep(0.1)
+    except:
+        print('There is no clean bot in this page.')
+
+    while True:
+        try:
+            more_button = driver.find_element_by_css_selector('a.u_cbox_btn_more')
+            more_button.click()
+            time.sleep(1)
+        except:
+            break
+
+    contents = driver.find_elements_by_css_selector('span.u_cbox_contents')
+    # Debugging -> print the comments.
+    if debug:
+        for content in contents:
+            print(content.text)
+
+    return contents
+
+
+if __name__ == "__main__":
+    url = 'https://news.naver.com/main/read.nhn?m_view=1&includeAllCount=true&mode=LSD&mid=shm&sid1=102&oid=022&aid=0003479487'
+    extract(url, debug=True)


### PR DESCRIPTION
- 네이버 뉴스의 댓글을 크롤링 하기위한 소스코드입니다.
- 테스트 겸 하나의 뉴스에 있는 댓글을 크롤링 해보았습니다.

테스트 주소 : https://news.naver.com/main/read.nhn?m_view=1&includeAllCount=true&mode=LSD&mid=shm&sid1=102&oid=022&aid=0003479487

### 추가 목표
- 자동적으로 모든 뉴스 기사에 접근하여 댓글을 크롤링할 수 있도록 해야합니다.
- 지금까지 조사해본 결과 아래와 같은 parameter들로 인해 url이 만들어지는 것을 확인하였습니다. 
> sid1, sid2, oid, aid
